### PR TITLE
Simplify link detection, discovers links in RDF feeds too.

### DIFF
--- a/src/p3k/WebSub/Client.php
+++ b/src/p3k/WebSub/Client.php
@@ -108,21 +108,13 @@ class Client {
             $type = $body['type'] = 'rss';
           } elseif($xpath->query('/atom:feed')->length) {
             $type = $body['type'] = 'atom';
+          } elseif($xpath->query('/rdf:RDF')->length) {
+            $type = $body['type'] = 'rdf';
           }
 
-          // Look for atom link elements in the feed        
-          foreach($xpath->query('/atom:feed/atom:link[@href]') as $link) {
-            $rel = $link->getAttribute('rel');
-            $url = $link->getAttribute('href');
-            if($rel == 'hub') {
-              $body['hub'][] = $url;
-            } else if($rel == 'self') {
-              $body['self'][] = $url;
-            }
-          }
-
-          // Some RSS feeds include the link element as an atom attribute
-          foreach($xpath->query('/rss/channel/atom:link[@href]') as $link) {
+          // Find all link elements in the feed.
+          $links = $dom->getElementsByTagName('link');
+          foreach ($links as $link) {
             $rel = $link->getAttribute('rel');
             $url = $link->getAttribute('href');
             if($rel == 'hub') {
@@ -213,7 +205,7 @@ class Client {
   }
 
   public static function verify_signature($body, $signature_header, $secret) {
-    if($signature_header && is_string($signature_header) 
+    if($signature_header && is_string($signature_header)
       && preg_match('/(sha(?:1|256|384|512))=(.+)/', $signature_header, $match)) {
       $alg = $match[1];
       $sig = $match[2];


### PR DESCRIPTION
http://feeds.feedburner.com/oatmealfeed self and hub couldn't be found with the current code in the feed.

This pull request simplifies the discovery within feeds which makes the discovery happen. Tested with http://feeds.feedburner.com/BeautifulNewsDaily - still works with this one too (worked before this patch as well)