### PR TITLE
Use timing attack safe signature verification

### DIFF
--- a/src/p3k/WebSub/Client.php
+++ b/src/p3k/WebSub/Client.php
@@ -218,7 +218,7 @@ class Client {
       $alg = $match[1];
       $sig = $match[2];
       $expected_signature = hash_hmac($alg, $body, $secret);
-      return $sig == $expected_signature;
+      return hash_equals($sig, $expected_signature);
     } else {
       return false;
     }


### PR DESCRIPTION
Makes verifying the hub signature a little more secure by using [`hash_equals()`](https://www.php.net/manual/en/function.hash-equals.php) to defeat timing attacks attempting to reveal the secret.